### PR TITLE
Stable support 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -90,21 +90,21 @@ in rec {
   };
 
   rust-std = args: let
-    pname = "rust-std";
-    inherit (dispatchFetch {
-      inherit pname;
-      archive = "https://static.rust-lang.org/dist";
-    } args) url system version src;
-  in stdenv.mkDerivation rec {
-    # Strip install.sh, etc
-    inherit pname version src;
-    name = "${pname}-${version}-${system}";
-    installPhase = ''
-      mkdir -p $out
-      mv ./*/* $out/
-      rm $out/manifest.in
-    '';
-  };
+      pname = "rust-std";
+      inherit (dispatchFetch {
+        inherit pname;
+        archive = "https://static.rust-lang.org/dist";
+      } args) url system version src;
+    in stdenv.mkDerivation rec {
+      # Strip install.sh, etc
+      inherit pname version src;
+      name = "${pname}-${version}-${system}";
+      installPhase = ''
+        mkdir -p $out
+        mv ./*/* $out/
+        rm $out/manifest.in
+      '';
+    };
 
   cargo = generic {
     pname = "cargo";

--- a/default.nix
+++ b/default.nix
@@ -41,10 +41,12 @@ let
     src = fetchurl { inherit url sha256; };
   };
 
-  generic = { pname, archive, exes }: args: let
-        inherit (dispatchFetch { inherit pname archive; } args)
-          url version src;
-      in stdenv.mkDerivation rec {
+  generic = { pname, archive, exes }: args: patchBin {
+    inherit pname exes;
+    inherit (dispatchFetch { inherit pname archive; } args) version src;
+  };
+
+  patchBin = { pname, version, src, exes }: stdenv.mkDerivation rec {
     name = "${pname}-${version}";
     inherit version src;
     # TODO meta;


### PR DESCRIPTION
Fixes #11

This as a *breaking* change as one must now do `{ channel = "nightly"; date = .... }`, i.e. `channel = "nightly"` is required, for clarity, and to disambiguate the entirely implicit case (data and hash).  

#12 might still be useful for docs and examples.