### PR TITLE
preferLocalBuild

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,7 @@ let
       stdenv.mkDerivation rec {
     name = "${pname}-${version}";
     version = "nightly-${date}";
+    preferLocalBuild = true;
     # TODO meta;
     outputs = [ "out" "doc" ];
     src = fetch (args // { inherit pname archive system date; });


### PR DESCRIPTION
For those of us who use remote build machines, it's not particularly
helpful to download the tarball of binaries locally, transfer it to the
build machine, unpack and patchelf the binaries there, and then transfer
them back.